### PR TITLE
Add missing libXss.so dependency

### DIFF
--- a/rendertron/Dockerfile
+++ b/rendertron/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt dist-upgrade -y && \
 	apt install -y wget gnupg2 && \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    apt-get update && apt-get -y install google-chrome-stable
+    apt-get update && apt-get -y install google-chrome-stable libxss1 
 
 ADD ./ /srv
 


### PR DESCRIPTION
Since the latest update of the rendertron image the stable-chrome browser cannot start with the given error: 
`error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory`

![image](https://user-images.githubusercontent.com/3903107/113516082-af06ba80-9578-11eb-8e40-2b4954102b7f.png)

Adding the libxss1 package to the Dockerfile solves this issue.

Tested on Windows 10 WSL2 Ubuntu.

