### PR TITLE
chore: normalize README maintenance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ docker run -it --rm -p 3000:3000 dockette/rendertron
 ```
 
 ![Screenshot](.docs/screenshot.png)
+
+## Maintenance
+
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ docker run -it --rm -p 3000:3000 dockette/rendertron
 
 ## Maintenance
 
-See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.


### PR DESCRIPTION
## What changed
- removed `Maintainers` sections where present
- normalized maintenance docs to this exact section content:
  - `## Maintenance`
  - `See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.`

## Why
- keep contribution and maintenance guidance consistent in all selected Dockette image READMEs